### PR TITLE
[feat]: Update sdk module reference and add how to compile or run doc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sdk"]
 	path = sdk
 	url = https://github.com/openmultiplayer/open.mp-sdk
+	branch = master

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ improve the generated code since we generate c# code instead of itermediate code
   - Install the Development to desktop with .NET
   - Install the Development to desktop with C++
 - [.NET 8 SDK x64](https://dotnet.microsoft.com/pt-br/download/dotnet/thank-you/sdk-8.0.404-windows-x64-installer)
-- [Open.MP Server x64](https://github.com/openmultiplayer/open.mp/actions/runs/11611054690/artifacts/2127938904)
+- [Open.MP Server x64](https://github.com/openmultiplayer/open.mp/actions/workflows/build.yml)
+  - Find and click in the last sucessfully run in `master` branch
+  - Scroll to the bottom of the page and download the `open.mp-win-x64-v*` file
 
 ##### Instructions
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,58 @@ supported by MS and may have stability issues.
 - The bridge between the .NET API and server API are generated at compile-time instead of at run-time. This means that
 the initial performance of the server should be better, it easier to diagnose issues in generated code and easier to
 improve the generated code since we generate c# code instead of itermediate code (IL).  
+
+
+## How to Compile/Run?
+
+##### Requirements
+
+- [Install CMake 3.19 +](https://cmake.org/download/)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/pt-br/vs/)
+  - Install the Development to desktop with .NET
+  - Install the Development to desktop with C++
+- [.NET 8 SDK x64](https://dotnet.microsoft.com/pt-br/download/dotnet/thank-you/sdk-8.0.404-windows-x64-installer)
+- [Open.MP Server x64](https://github.com/openmultiplayer/open.mp/actions/runs/11611054690/artifacts/2127938904)
+
+##### Instructions
+
+- Clone the repository:
+  - `git clone https://github.com/SampSharp/openmp-sampsharp-x64-poc`
+
+- In the project directory, initialize and update GIT submodules:
+  - `git submodule update --init --recursive`
+  - check if all git submodules of the `sdk` folder have also been cloned
+    - Just see if exists content inside `sdk/lib/glm`, `sdk/lib/robin-hood-hashing`, `sdk/lib/span-lite`, `sdk/lib/string-view-lite` submodules.
+
+- Have the directory where open.mp x64 server is located at hand
+
+- Setup the launchSettings.json:
+  - Navigate to `managed/SashManaged/SashManaged/Properties/launchSettings.json`.
+  - Update `executablePath` and `workingDirectory` according to your open.mp x64 server dir
+
+- Setup the CMake:
+  - Open CMakeLists.txt
+  - Set your <i>CMAKE\_</i> variables on L18~L24 according to your open.mp x64 server dir
+
+- Compile the C++ project:
+  - `mkdir build && cd build && cmake .. -A x64 -T ClangCL`
+
+- Open the `build` folder and open `.sln` file with the Visual Studio (VS)
+
+- Build the solution:
+  - Press `CTRL+SHIFT+B` or Right click on the solution on VS and go to the Build Solution option
+
+- Setup the `config.json` file of Open.MP
+  - Add the `sampsharp` property in config.json and change the value of `folder` property according of your path:
+  ```
+  "sampsharp": {
+      "folder": "D:\\Projects\\community\\openmp-sampsharp-x64-poc\\managed\\SashManaged\\SashManaged\\bin\\Debug\\net8.0\\",
+      "assembly": "SashManaged"
+  }
+  ```
+
+- Run the Open.MP server
+  - Go to `managed/SashManaged/SashManaged` and open the `.csproj` file with the VS
+  - Run the `open.mp` profile on VS
+
+- Let's go

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ improve the generated code since we generate c# code instead of itermediate code
 - [Visual Studio 2022](https://visualstudio.microsoft.com/pt-br/vs/)
   - Install the Development to desktop with .NET
   - Install the Development to desktop with C++
-- [.NET 8 SDK x64](https://dotnet.microsoft.com/pt-br/download/dotnet/thank-you/sdk-8.0.404-windows-x64-installer)
+- [.NET 8 SDK x64](https://dotnet.microsoft.com/pt-br/download)
+  - Download and install the .NET 8.0
 - [Open.MP Server x64](https://github.com/openmultiplayer/open.mp/actions/workflows/build.yml)
   - Find and click in the last sucessfully run in `master` branch
   - Scroll to the bottom of the page and download the `open.mp-win-x64-v*` file

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ supported by MS and may have stability issues.
 the initial performance of the server should be better, it easier to diagnose issues in generated code and easier to
 improve the generated code since we generate c# code instead of itermediate code (IL).  
 
-
 ## How to Compile/Run?
 
 ##### Requirements


### PR DESCRIPTION
## Summary

We can use the latest version of the sdk without conan, basically need to make sure that the git submodules are actually cloned, and the nexts steps to compile will work.

Additionally, a new document has been added with detailed instructions on how to run the project.