### PR TITLE
Added component version checker

### DIFF
--- a/src/SampSharp.OpenMp.Core/SampSharpInitParams.cs
+++ b/src/SampSharp.OpenMp.Core/SampSharpInitParams.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using SampSharp.OpenMp.Core.Api;
+using SampSharp.OpenMp.Core.Std;
 
 namespace SampSharp.OpenMp.Core;
 
@@ -7,8 +8,15 @@ namespace SampSharp.OpenMp.Core;
 /// Provides the parameters for initializing the SampSharp application as provided by the SampSharp open.mp component.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly ref struct SampSharpInitParams
+public readonly struct SampSharpInitParams
 {
+    /// <summary>
+    /// The size of this structure. Can be used to check if the structure is the correct version.
+    /// </summary>
+    public readonly Size Size;
+
+    private readonly BlittableStructRef<SampSharpInfo> _info;
+
     /// <summary>
     /// The open.mp core.
     /// </summary>
@@ -18,8 +26,6 @@ public readonly ref struct SampSharpInitParams
     /// The open.mp component list.
     /// </summary>
     public readonly IComponentList ComponentList;
-
-    private readonly BlittableStructRef<SampSharpInfo> _info;
 
     /// <summary>
     /// Gets information about the SampSharp open.mp component.

--- a/src/SampSharp.OpenMp.Core/SampSharpInitParams.cs
+++ b/src/SampSharp.OpenMp.Core/SampSharpInitParams.cs
@@ -8,7 +8,7 @@ namespace SampSharp.OpenMp.Core;
 /// Provides the parameters for initializing the SampSharp application as provided by the SampSharp open.mp component.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct SampSharpInitParams
+public readonly ref struct SampSharpInitParams
 {
     /// <summary>
     /// The size of this structure. Can be used to check if the structure is the correct version.

--- a/src/SampSharp.OpenMp.Core/StartupContext.cs
+++ b/src/SampSharp.OpenMp.Core/StartupContext.cs
@@ -93,15 +93,26 @@ public sealed class StartupContext : IStartupContext
     {
         unsafe
         {
-            if (init.Size.Value != sizeof(SampSharpInitParams) || 
-                init.Info.Size.Value != sizeof(SampSharpInfo) || 
-                init.Info.ApiVersion != SupportedApiVersion)
-            {
-                var version = typeof(StartupContext).Assembly.GetName().Version!.ToString(3);
+            var initParamsSizeMatches = init.Size.Value == sizeof(SampSharpInitParams);
+            var infoSizeMatches = init.Info.Size.Value == sizeof(SampSharpInfo);
+            var apiVersionMatches = init.Info.ApiVersion == SupportedApiVersion;
 
-                // TODO: Write docs
-                throw new InvalidOperationException($"SampSharp version mismatch. The SampSharp open.mp component does not support SampSharp.OpenMp.Core v{version}. See https://sampsharp.net/version-mismatch.html for more details.");
+            if (initParamsSizeMatches && infoSizeMatches && apiVersionMatches)
+            {
+                return;
             }
+
+            var version = typeof(StartupContext).Assembly.GetName().Version!.ToString(3);
+
+            // TODO: Write docs
+            var message = $"SampSharp version mismatch. The SampSharp open.mp component does not support SampSharp.OpenMp.Core v{version}. See https://sampsharp.net/version-mismatch.html for more details.";
+
+            if (initParamsSizeMatches && infoSizeMatches)
+            {
+                init.Core.LogLine(LogLevel.Error, message);
+            }
+
+            Environment.FailFast(message);
         }
     }
 }

--- a/src/SampSharp.OpenMp.Core/StartupContext.cs
+++ b/src/SampSharp.OpenMp.Core/StartupContext.cs
@@ -7,6 +7,11 @@ namespace SampSharp.OpenMp.Core;
 /// </summary>
 public sealed class StartupContext : IStartupContext
 {
+    /// <summary>
+    /// The API version of the native open.mp component which supports this version of the managed API. This is used to check for version mismatches between the managed and native components.
+    /// </summary>
+    private const int SupportedApiVersion = 1;
+
     private IStartup? _configurator;
     private ExceptionHandler _unhandledExceptionHandler;
 
@@ -16,6 +21,7 @@ public sealed class StartupContext : IStartupContext
     /// <param name="init">The initialization parameters.</param>
     public StartupContext(SampSharpInitParams init)
     {
+        VersionCheck(init);
         Core = init.Core;
         ComponentList = init.ComponentList;
         Info = init.Info;
@@ -81,5 +87,21 @@ public sealed class StartupContext : IStartupContext
     public static void MainInfoProvider()
     {
         LaunchInstructions.Write();
+    }
+
+    private static void VersionCheck(SampSharpInitParams init)
+    {
+        unsafe
+        {
+            if (init.Size.Value != sizeof(SampSharpInitParams) || 
+                init.Info.Size.Value != sizeof(SampSharpInfo) || 
+                init.Info.ApiVersion != SupportedApiVersion)
+            {
+                var version = typeof(StartupContext).Assembly.GetName().Version!.ToString(3);
+
+                // TODO: Write docs
+                throw new InvalidOperationException($"SampSharp version mismatch. The SampSharp open.mp component does not support SampSharp.OpenMp.Core v{version}. See https://sampsharp.net/version-mismatch.html for more details.");
+            }
+        }
     }
 }

--- a/src/SampSharp.OpenMp.Core/StructPointer.cs
+++ b/src/SampSharp.OpenMp.Core/StructPointer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace SampSharp.OpenMp.Core;
 

--- a/src/sampsharp-component/crash-handler.cpp
+++ b/src/sampsharp-component/crash-handler.cpp
@@ -15,324 +15,324 @@
 
 namespace sampsharp::crash
 {
-	namespace
-	{
-		ICore* g_core = nullptr;
-		std::atomic<bool> g_handling{false};
-		std::atomic<bool> g_sym_initialized{false};
+    namespace
+    {
+        ICore* g_core = nullptr;
+        std::atomic<bool> g_handling{false};
+        std::atomic<bool> g_sym_initialized{false};
 
-		const char* codeName(const DWORD code)
-		{
-			switch (code)
-			{
-			case EXCEPTION_ACCESS_VIOLATION:      return "ACCESS_VIOLATION";
-			case EXCEPTION_STACK_OVERFLOW:        return "STACK_OVERFLOW";
-			case EXCEPTION_ILLEGAL_INSTRUCTION:   return "ILLEGAL_INSTRUCTION";
-			case EXCEPTION_PRIV_INSTRUCTION:      return "PRIV_INSTRUCTION";
-			case EXCEPTION_INT_DIVIDE_BY_ZERO:    return "INT_DIVIDE_BY_ZERO";
-			case EXCEPTION_INT_OVERFLOW:          return "INT_OVERFLOW";
-			case EXCEPTION_FLT_DIVIDE_BY_ZERO:    return "FLT_DIVIDE_BY_ZERO";
-			case EXCEPTION_ARRAY_BOUNDS_EXCEEDED: return "ARRAY_BOUNDS_EXCEEDED";
-			case EXCEPTION_DATATYPE_MISALIGNMENT: return "DATATYPE_MISALIGNMENT";
-			case EXCEPTION_IN_PAGE_ERROR:         return "IN_PAGE_ERROR";
-			case 0xC0000374:                      return "HEAP_CORRUPTION";
-			case 0xC0000409:                      return "FAST_FAIL/STACK_BUFFER_OVERRUN";
-			case 0xE06D7363:                      return "C++ EXCEPTION";
-			case 0xE0434352:                      return "CLR EXCEPTION";
-			default:                              return "UNKNOWN";
-			}
-		}
+        const char* codeName(const DWORD code)
+        {
+            switch (code)
+            {
+            case EXCEPTION_ACCESS_VIOLATION:      return "ACCESS_VIOLATION";
+            case EXCEPTION_STACK_OVERFLOW:        return "STACK_OVERFLOW";
+            case EXCEPTION_ILLEGAL_INSTRUCTION:   return "ILLEGAL_INSTRUCTION";
+            case EXCEPTION_PRIV_INSTRUCTION:      return "PRIV_INSTRUCTION";
+            case EXCEPTION_INT_DIVIDE_BY_ZERO:    return "INT_DIVIDE_BY_ZERO";
+            case EXCEPTION_INT_OVERFLOW:          return "INT_OVERFLOW";
+            case EXCEPTION_FLT_DIVIDE_BY_ZERO:    return "FLT_DIVIDE_BY_ZERO";
+            case EXCEPTION_ARRAY_BOUNDS_EXCEEDED: return "ARRAY_BOUNDS_EXCEEDED";
+            case EXCEPTION_DATATYPE_MISALIGNMENT: return "DATATYPE_MISALIGNMENT";
+            case EXCEPTION_IN_PAGE_ERROR:         return "IN_PAGE_ERROR";
+            case 0xC0000374:                      return "HEAP_CORRUPTION";
+            case 0xC0000409:                      return "FAST_FAIL/STACK_BUFFER_OVERRUN";
+            case 0xE06D7363:                      return "C++ EXCEPTION";
+            case 0xE0434352:                      return "CLR EXCEPTION";
+            default:                              return "UNKNOWN";
+            }
+        }
 
-		void vlog(const char* fmt, va_list ap)
-		{
-			char buf[4096];
-			vsnprintf(buf, sizeof(buf), fmt, ap);
-			buf[sizeof(buf) - 1] = 0;
-			if (g_core)
-				g_core->logLn(LogLevel::Error, "%s", buf);
-			else
-			{
-				fputs(buf, stderr);
-				fputc('\n', stderr);
-			}
-		}
+        void vlog(const char* fmt, va_list ap)
+        {
+            char buf[4096];
+            vsnprintf(buf, sizeof(buf), fmt, ap);
+            buf[sizeof(buf) - 1] = 0;
+            if (g_core)
+                g_core->logLn(LogLevel::Error, "%s", buf);
+            else
+            {
+                fputs(buf, stderr);
+                fputc('\n', stderr);
+            }
+        }
 
-		void log(const char* fmt, ...)
-		{
-			va_list ap;
-			va_start(ap, fmt);
-			vlog(fmt, ap);
-			va_end(ap);
-		}
+        void log(const char* fmt, ...)
+        {
+            va_list ap;
+            va_start(ap, fmt);
+            vlog(fmt, ap);
+            va_end(ap);
+        }
 
-		void logModuleFor(void* addr)
-		{
-			HMODULE mod = nullptr;
-			if (!GetModuleHandleExA(
-				GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-				static_cast<LPCSTR>(addr), &mod) || !mod)
-			{
-				log("  %p  <unknown module>", addr);
-				return;
-			}
-			char modPath[MAX_PATH] = {};
-			GetModuleFileNameA(mod, modPath, MAX_PATH);
-			const char* modName = strrchr(modPath, '\\');
-			modName = modName ? modName + 1 : modPath;
-			const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(mod);
+        void logModuleFor(void* addr)
+        {
+            HMODULE mod = nullptr;
+            if (!GetModuleHandleExA(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                static_cast<LPCSTR>(addr), &mod) || !mod)
+            {
+                log("  %p  <unknown module>", addr);
+                return;
+            }
+            char modPath[MAX_PATH] = {};
+            GetModuleFileNameA(mod, modPath, MAX_PATH);
+            const char* modName = strrchr(modPath, '\\');
+            modName = modName ? modName + 1 : modPath;
+            const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(mod);
 
-			char symStorage[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = {};
-			auto* sym = reinterpret_cast<SYMBOL_INFO*>(symStorage);
-			sym->SizeOfStruct = sizeof(SYMBOL_INFO);
-			sym->MaxNameLen = MAX_SYM_NAME;
-			DWORD64 disp = 0;
-			IMAGEHLP_LINE64 line{};
-			line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
-			DWORD lineDisp = 0;
+            char symStorage[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = {};
+            auto* sym = reinterpret_cast<SYMBOL_INFO*>(symStorage);
+            sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+            sym->MaxNameLen = MAX_SYM_NAME;
+            DWORD64 disp = 0;
+            IMAGEHLP_LINE64 line{};
+            line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+            DWORD lineDisp = 0;
 
-			const DWORD64 pc = reinterpret_cast<DWORD64>(addr);
-			const BOOL haveSym = SymFromAddr(GetCurrentProcess(), pc, &disp, sym);
-			const BOOL haveLine = SymGetLineFromAddr64(GetCurrentProcess(), pc, &lineDisp, &line);
+            const DWORD64 pc = reinterpret_cast<DWORD64>(addr);
+            const BOOL haveSym = SymFromAddr(GetCurrentProcess(), pc, &disp, sym);
+            const BOOL haveLine = SymGetLineFromAddr64(GetCurrentProcess(), pc, &lineDisp, &line);
 
-			if (haveSym && haveLine)
-				log("  %p  %s!%s+0x%llx  (%s:%lu)", addr, modName, sym->Name,
-				    static_cast<unsigned long long>(disp), line.FileName, line.LineNumber);
-			else if (haveSym)
-				log("  %p  %s!%s+0x%llx", addr, modName, sym->Name,
-				    static_cast<unsigned long long>(disp));
-			else
-				log("  %p  %s+0x%llx", addr, modName,
-				    static_cast<unsigned long long>(offset));
-		}
+            if (haveSym && haveLine)
+                log("  %p  %s!%s+0x%llx  (%s:%lu)", addr, modName, sym->Name,
+                    static_cast<unsigned long long>(disp), line.FileName, line.LineNumber);
+            else if (haveSym)
+                log("  %p  %s!%s+0x%llx", addr, modName, sym->Name,
+                    static_cast<unsigned long long>(disp));
+            else
+                log("  %p  %s+0x%llx", addr, modName,
+                    static_cast<unsigned long long>(offset));
+        }
 
-		// Safely read 8 bytes from a possibly-bad address. Returns false on fault.
-		// Extracted into its own function because MSVC forbids __try in functions
-		// with C++ objects that have destructors (e.g. std::lock_guard below).
-		bool safeRead64(const DWORD64 addr, DWORD64* out)
-		{
-			__try
-			{
-				*out = *reinterpret_cast<DWORD64*>(addr);
-				return true;
-			}
-			__except (EXCEPTION_EXECUTE_HANDLER)
-			{
-				return false;
-			}
-		}
+        // Safely read 8 bytes from a possibly-bad address. Returns false on fault.
+        // Extracted into its own function because MSVC forbids __try in functions
+        // with C++ objects that have destructors (e.g. std::lock_guard below).
+        bool safeRead64(const DWORD64 addr, DWORD64* out)
+        {
+            __try
+            {
+                *out = *reinterpret_cast<DWORD64*>(addr);
+                return true;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return false;
+            }
+        }
 
-		void logStackTrace(CONTEXT* ctx)
-		{
-			static std::mutex walkMutex;
-			std::lock_guard<std::mutex> lock(walkMutex);
+        void logStackTrace(CONTEXT* ctx)
+        {
+            static std::mutex walkMutex;
+            std::lock_guard<std::mutex> lock(walkMutex);
 
-			const HANDLE process = GetCurrentProcess();
-			if (!g_sym_initialized.exchange(true))
-			{
-				SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS);
-				SymInitialize(process, nullptr, TRUE);
-			}
-			else
-			{
-				SymRefreshModuleList(process);
-			}
+            const HANDLE process = GetCurrentProcess();
+            if (!g_sym_initialized.exchange(true))
+            {
+                SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS);
+                SymInitialize(process, nullptr, TRUE);
+            }
+            else
+            {
+                SymRefreshModuleList(process);
+            }
 
-			CONTEXT walkCtx = *ctx;
-			DWORD machine;
-			STACKFRAME64 frame{};
+            CONTEXT walkCtx = *ctx;
+            DWORD machine;
+            STACKFRAME64 frame{};
 #ifdef _M_X64
-			machine = IMAGE_FILE_MACHINE_AMD64;
+            machine = IMAGE_FILE_MACHINE_AMD64;
 
-			// If PC is bogus (null-call via bad function pointer or vtable),
-			// StackWalk64 can't find unwind info and bails on the first frame.
-			// Recover by lifting the return address off the top of the stack
-			// so we at least see the caller. [Rsp] holds the return address
-			// pushed by the call that jumped to the invalid target.
-			bool recovered_pc = false;
-			if (walkCtx.Rip == 0 || walkCtx.Rip < 0x10000)
-			{
-				log("[crash] PC is invalid (0x%llx) - recovering caller from [Rsp]",
-				    static_cast<unsigned long long>(walkCtx.Rip));
-				DWORD64 retAddr = 0;
-				if (safeRead64(walkCtx.Rsp, &retAddr))
-				{
-					walkCtx.Rip = retAddr;
-					walkCtx.Rsp += sizeof(DWORD64);
-					recovered_pc = true;
-					log("[crash] recovered caller PC: 0x%llx",
-					    static_cast<unsigned long long>(retAddr));
-				}
-				else
-				{
-					log("[crash] could not read return address from stack");
-				}
-			}
+            // If PC is bogus (null-call via bad function pointer or vtable),
+            // StackWalk64 can't find unwind info and bails on the first frame.
+            // Recover by lifting the return address off the top of the stack
+            // so we at least see the caller. [Rsp] holds the return address
+            // pushed by the call that jumped to the invalid target.
+            bool recovered_pc = false;
+            if (walkCtx.Rip == 0 || walkCtx.Rip < 0x10000)
+            {
+                log("[crash] PC is invalid (0x%llx) - recovering caller from [Rsp]",
+                    static_cast<unsigned long long>(walkCtx.Rip));
+                DWORD64 retAddr = 0;
+                if (safeRead64(walkCtx.Rsp, &retAddr))
+                {
+                    walkCtx.Rip = retAddr;
+                    walkCtx.Rsp += sizeof(DWORD64);
+                    recovered_pc = true;
+                    log("[crash] recovered caller PC: 0x%llx",
+                        static_cast<unsigned long long>(retAddr));
+                }
+                else
+                {
+                    log("[crash] could not read return address from stack");
+                }
+            }
 
-			frame.AddrPC.Offset = walkCtx.Rip;
-			frame.AddrFrame.Offset = walkCtx.Rbp;
-			frame.AddrStack.Offset = walkCtx.Rsp;
+            frame.AddrPC.Offset = walkCtx.Rip;
+            frame.AddrFrame.Offset = walkCtx.Rbp;
+            frame.AddrStack.Offset = walkCtx.Rsp;
 #else
-			machine = IMAGE_FILE_MACHINE_I386;
-			bool recovered_pc = false;
-			frame.AddrPC.Offset = walkCtx.Eip;
-			frame.AddrFrame.Offset = walkCtx.Ebp;
-			frame.AddrStack.Offset = walkCtx.Esp;
+            machine = IMAGE_FILE_MACHINE_I386;
+            bool recovered_pc = false;
+            frame.AddrPC.Offset = walkCtx.Eip;
+            frame.AddrFrame.Offset = walkCtx.Ebp;
+            frame.AddrStack.Offset = walkCtx.Esp;
 #endif
-			frame.AddrPC.Mode = AddrModeFlat;
-			frame.AddrFrame.Mode = AddrModeFlat;
-			frame.AddrStack.Mode = AddrModeFlat;
+            frame.AddrPC.Mode = AddrModeFlat;
+            frame.AddrFrame.Mode = AddrModeFlat;
+            frame.AddrStack.Mode = AddrModeFlat;
 
-			log("[crash] stack trace%s:", recovered_pc ? " (starting from recovered caller)" : "");
-			int walked = 0;
-			for (int i = 0; i < 64; ++i)
-			{
-				if (!StackWalk64(machine, process, GetCurrentThread(), &frame, &walkCtx,
-				                 nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr))
-					break;
-				if (frame.AddrPC.Offset == 0)
-					break;
-				logModuleFor(reinterpret_cast<void*>(frame.AddrPC.Offset));
-				++walked;
-			}
+            log("[crash] stack trace%s:", recovered_pc ? " (starting from recovered caller)" : "");
+            int walked = 0;
+            for (int i = 0; i < 64; ++i)
+            {
+                if (!StackWalk64(machine, process, GetCurrentThread(), &frame, &walkCtx,
+                                 nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr))
+                    break;
+                if (frame.AddrPC.Offset == 0)
+                    break;
+                logModuleFor(reinterpret_cast<void*>(frame.AddrPC.Offset));
+                ++walked;
+            }
 
-			// If StackWalk64 gave us nothing (bad PC, no unwind info for the
-			// top frame), fall back to scanning the stack for values that look
-			// like return addresses into known modules. Noisy but often the
-			// only signal we get for null-call / corrupted-vtable crashes.
-			if (walked == 0)
-			{
-				log("[crash] stack walk yielded 0 frames - scanning raw stack for return addresses:");
-				const DWORD64 rsp = ctx->Rsp;
-				int found = 0;
-				for (int i = 0; i < 512 && found < 32; ++i)
-				{
-					DWORD64 val = 0;
-					if (!safeRead64(rsp + i * sizeof(DWORD64), &val))
-						break;
-					if (val < 0x10000) continue;
-					HMODULE mod = nullptr;
-					if (GetModuleHandleExA(
-						    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-						    reinterpret_cast<LPCSTR>(val), &mod) && mod)
-					{
-						logModuleFor(reinterpret_cast<void*>(val));
-						++found;
-					}
-				}
-				if (found == 0)
-					log("[crash] no return addresses found on stack");
-			}
-		}
+            // If StackWalk64 gave us nothing (bad PC, no unwind info for the
+            // top frame), fall back to scanning the stack for values that look
+            // like return addresses into known modules. Noisy but often the
+            // only signal we get for null-call / corrupted-vtable crashes.
+            if (walked == 0)
+            {
+                log("[crash] stack walk yielded 0 frames - scanning raw stack for return addresses:");
+                const DWORD64 rsp = ctx->Rsp;
+                int found = 0;
+                for (int i = 0; i < 512 && found < 32; ++i)
+                {
+                    DWORD64 val = 0;
+                    if (!safeRead64(rsp + i * sizeof(DWORD64), &val))
+                        break;
+                    if (val < 0x10000) continue;
+                    HMODULE mod = nullptr;
+                    if (GetModuleHandleExA(
+                            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCSTR>(val), &mod) && mod)
+                    {
+                        logModuleFor(reinterpret_cast<void*>(val));
+                        ++found;
+                    }
+                }
+                if (found == 0)
+                    log("[crash] no return addresses found on stack");
+            }
+        }
 
-		void writeMinidump(EXCEPTION_POINTERS* ep)
-		{
-			char path[MAX_PATH];
-			SYSTEMTIME st;
-			GetLocalTime(&st);
-			snprintf(path, sizeof(path),
-			         "sampsharp_crash_%04u%02u%02u_%02u%02u%02u_%lu.dmp",
-			         st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
-			         GetCurrentProcessId());
+        void writeMinidump(EXCEPTION_POINTERS* ep)
+        {
+            char path[MAX_PATH];
+            SYSTEMTIME st;
+            GetLocalTime(&st);
+            snprintf(path, sizeof(path),
+                     "sampsharp_crash_%04u%02u%02u_%02u%02u%02u_%lu.dmp",
+                     st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
+                     GetCurrentProcessId());
 
-			const HANDLE file = CreateFileA(path, GENERIC_WRITE, 0, nullptr,
-			                                CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-			if (file == INVALID_HANDLE_VALUE)
-			{
-				log("[crash] failed to create minidump file '%s' (err=%lu)", path, GetLastError());
-				return;
-			}
+            const HANDLE file = CreateFileA(path, GENERIC_WRITE, 0, nullptr,
+                                            CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (file == INVALID_HANDLE_VALUE)
+            {
+                log("[crash] failed to create minidump file '%s' (err=%lu)", path, GetLastError());
+                return;
+            }
 
-			MINIDUMP_EXCEPTION_INFORMATION mei{};
-			mei.ThreadId = GetCurrentThreadId();
-			mei.ExceptionPointers = ep;
-			mei.ClientPointers = FALSE;
+            MINIDUMP_EXCEPTION_INFORMATION mei{};
+            mei.ThreadId = GetCurrentThreadId();
+            mei.ExceptionPointers = ep;
+            mei.ClientPointers = FALSE;
 
-			const auto type = static_cast<MINIDUMP_TYPE>(
-				MiniDumpWithFullMemory |
-				MiniDumpWithHandleData |
-				MiniDumpWithThreadInfo |
-				MiniDumpWithUnloadedModules |
-				MiniDumpWithFullMemoryInfo);
+            const auto type = static_cast<MINIDUMP_TYPE>(
+                MiniDumpWithFullMemory |
+                MiniDumpWithHandleData |
+                MiniDumpWithThreadInfo |
+                MiniDumpWithUnloadedModules |
+                MiniDumpWithFullMemoryInfo);
 
-			const BOOL ok = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(),
-			                                  file, type, ep ? &mei : nullptr, nullptr, nullptr);
-			CloseHandle(file);
+            const BOOL ok = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(),
+                                              file, type, ep ? &mei : nullptr, nullptr, nullptr);
+            CloseHandle(file);
 
-			if (ok)
-				log("[crash] minidump written: %s", path);
-			else
-				log("[crash] MiniDumpWriteDump failed (err=%lu)", GetLastError());
-		}
+            if (ok)
+                log("[crash] minidump written: %s", path);
+            else
+                log("[crash] MiniDumpWriteDump failed (err=%lu)", GetLastError());
+        }
 
-		LONG WINAPI unhandledFilter(EXCEPTION_POINTERS* ep)
-		{
-			bool expected = false;
-			if (!g_handling.compare_exchange_strong(expected, true))
-				return EXCEPTION_CONTINUE_SEARCH;
+        LONG WINAPI unhandledFilter(EXCEPTION_POINTERS* ep)
+        {
+            bool expected = false;
+            if (!g_handling.compare_exchange_strong(expected, true))
+                return EXCEPTION_CONTINUE_SEARCH;
 
-			const DWORD code = ep->ExceptionRecord->ExceptionCode;
-			void* addr = ep->ExceptionRecord->ExceptionAddress;
+            const DWORD code = ep->ExceptionRecord->ExceptionCode;
+            void* addr = ep->ExceptionRecord->ExceptionAddress;
 
-			log("================ SampSharp CRASH ================");
-			log("[crash] code=0x%08lX (%s)  addr=%p  thread=%lu  pid=%lu",
-			    code, codeName(code), addr,
-			    GetCurrentThreadId(), GetCurrentProcessId());
+            log("================ SampSharp CRASH ================");
+            log("[crash] code=0x%08lX (%s)  addr=%p  thread=%lu  pid=%lu",
+                code, codeName(code), addr,
+                GetCurrentThreadId(), GetCurrentProcessId());
 
-			if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2)
-			{
-				const ULONG_PTR kind = ep->ExceptionRecord->ExceptionInformation[0];
-				const auto av_addr = reinterpret_cast<void*>(ep->ExceptionRecord->ExceptionInformation[1]);
-				const char* verb = kind == 0 ? "read from" : kind == 1 ? "write to" : "execute (DEP) at";
-				log("[crash] access violation: %s %p", verb, av_addr);
-			}
+            if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2)
+            {
+                const ULONG_PTR kind = ep->ExceptionRecord->ExceptionInformation[0];
+                const auto av_addr = reinterpret_cast<void*>(ep->ExceptionRecord->ExceptionInformation[1]);
+                const char* verb = kind == 0 ? "read from" : kind == 1 ? "write to" : "execute (DEP) at";
+                log("[crash] access violation: %s %p", verb, av_addr);
+            }
 
-			log("[crash] faulting instruction:");
-			logModuleFor(addr);
+            log("[crash] faulting instruction:");
+            logModuleFor(addr);
 
-			logStackTrace(ep->ContextRecord);
-			writeMinidump(ep);
+            logStackTrace(ep->ContextRecord);
+            writeMinidump(ep);
 
-			if (code == 0xC0000374)
-			{
-				log("[crash] HEAP_CORRUPTION is a delayed symptom - the real bug wrote");
-				log("[crash] out-of-bounds (or freed twice) earlier on another code path.");
-				log("[crash] To pinpoint it, enable PageHeap once, reproduce, then disable:");
-				log("[crash]   gflags /p /enable omp-server.exe /full");
-				log("[crash]   gflags /p /disable omp-server.exe");
-				log("[crash] With PageHeap the crash happens exactly at the bad write.");
-			}
-			log("=================================================");
+            if (code == 0xC0000374)
+            {
+                log("[crash] HEAP_CORRUPTION is a delayed symptom - the real bug wrote");
+                log("[crash] out-of-bounds (or freed twice) earlier on another code path.");
+                log("[crash] To pinpoint it, enable PageHeap once, reproduce, then disable:");
+                log("[crash]   gflags /p /enable omp-server.exe /full");
+                log("[crash]   gflags /p /disable omp-server.exe");
+                log("[crash] With PageHeap the crash happens exactly at the bad write.");
+            }
+            log("=================================================");
 
-			// Let the OS take it from here (WER / default termination).
-			return EXCEPTION_CONTINUE_SEARCH;
-		}
+            // Let the OS take it from here (WER / default termination).
+            return EXCEPTION_CONTINUE_SEARCH;
+        }
 
-		LPTOP_LEVEL_EXCEPTION_FILTER g_previous_filter = nullptr;
-	}
+        LPTOP_LEVEL_EXCEPTION_FILTER g_previous_filter = nullptr;
+    }
 
-	void install(ICore* core)
-	{
-		g_core = core;
+    void install(ICore* core)
+    {
+        g_core = core;
 
-		// Some CRT/host code calls SetUnhandledExceptionFilter(nullptr) to
-		// disable user filters. Re-arm ours and keep the previous one for
-		// chaining in case another component installs its own later.
-		g_previous_filter = SetUnhandledExceptionFilter(unhandledFilter);
+        // Some CRT/host code calls SetUnhandledExceptionFilter(nullptr) to
+        // disable user filters. Re-arm ours and keep the previous one for
+        // chaining in case another component installs its own later.
+        g_previous_filter = SetUnhandledExceptionFilter(unhandledFilter);
 
-		// Don't let WER silently swallow fatal errors without giving us a chance.
-		const UINT old = SetErrorMode(0);
-		SetErrorMode(old | SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
+        // Don't let WER silently swallow fatal errors without giving us a chance.
+        const UINT old = SetErrorMode(0);
+        SetErrorMode(old | SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
 
-		if (core)
-			core->logLn(LogLevel::Message, "[SampSharp] crash handler installed");
-	}
+        if (core)
+            core->logLn(LogLevel::Message, "[SampSharp] crash handler installed");
+    }
 }
 
 #else // !_WIN32
 
 namespace sampsharp::crash
 {
-	void install(ICore*) {}
+    void install(ICore*) {}
 }
 
 #endif

--- a/src/sampsharp-component/crash-handler.hpp
+++ b/src/sampsharp-component/crash-handler.hpp
@@ -4,9 +4,9 @@
 
 namespace sampsharp::crash
 {
-	// Installs a process-wide crash handler. Safe to call once during onLoad.
-	// On Windows: top-level SEH filter + vectored continue handler that logs
-	// exception code/address, module, stack trace, and writes a minidump next
-	// to the executable. No-op on other platforms.
-	void install(ICore* core);
+    // Installs a process-wide crash handler. Safe to call once during onLoad.
+    // On Windows: top-level SEH filter + vectored continue handler that logs
+    // exception code/address, module, stack trace, and writes a minidump next
+    // to the executable. No-op on other platforms.
+    void install(ICore* core);
 }

--- a/src/sampsharp-component/main.cpp
+++ b/src/sampsharp-component/main.cpp
@@ -4,5 +4,5 @@
 
 COMPONENT_ENTRY_POINT()
 {
-	return SampSharpComponent::getInstance();
+    return SampSharpComponent::getInstance();
 }

--- a/src/sampsharp-component/managed-host.cpp
+++ b/src/sampsharp-component/managed-host.cpp
@@ -135,7 +135,7 @@ int ManagedHost::load_hostfxr(const char_t * assembly_path)
     // Load hostfxr and get desired exports
     void *lib = load_library(buffer);
     init_for_config_fptr = (hostfxr_initialize_for_runtime_config_fn)get_export(lib, "hostfxr_initialize_for_runtime_config");
-	get_delegate_fptr = (hostfxr_get_runtime_delegate_fn)get_export(lib, "hostfxr_get_runtime_delegate");
+    get_delegate_fptr = (hostfxr_get_runtime_delegate_fn)get_export(lib, "hostfxr_get_runtime_delegate");
     close_fptr = (hostfxr_close_fn)get_export(lib, "hostfxr_close");
  
     if (!init_for_config_fptr || !get_delegate_fptr || !close_fptr)

--- a/src/sampsharp-component/proxy-api.hpp
+++ b/src/sampsharp-component/proxy-api.hpp
@@ -178,15 +178,15 @@ namespace sampsharp
 
 /// proxy for event dispatcher functions and function to get the event dispatcher
 #define PROXY_EVENT_DISPATCHER(type_subject, type_handler, method) \
-	PROXY(type_subject, IEventDispatcher<type_handler>&, method);
+    PROXY(type_subject, IEventDispatcher<type_handler>&, method);
 
 /// proxy for event dispatcher functions and function to get the event dispatcher wit specific handler name
 #define PROXY_EVENT_DISPATCHER_NAMED(type_subject, handler_type, handler_name, method) \
-	PROXY(type_subject, IEventDispatcher<handler_type>&, method);
+    PROXY(type_subject, IEventDispatcher<handler_type>&, method);
 
 /// proxy for event dispatcher functions and function to get the event dispatcher
 #define PROXY_INDEXED_EVENT_DISPATCHER(type_subject, type_handler, method) \
-	PROXY(type_subject, IIndexedEventDispatcher<type_handler>&, method);
+    PROXY(type_subject, IIndexedEventDispatcher<type_handler>&, method);
 
 /// start of event handler proxy class 
 #define PROXY_EVENT_HANDLER_BEGIN(handler_type) \

--- a/src/sampsharp-component/sampsharp-component.cpp
+++ b/src/sampsharp-component/sampsharp-component.cpp
@@ -10,18 +10,18 @@
 
 StringView SampSharpComponent::componentName() const
 {
-	return "SampSharp";
+    return "SampSharp";
 }
 
 SemanticVersion SampSharpComponent::componentVersion() const
 {
-	return { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILD };
+    return { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILD };
 }
 
 void SampSharpComponent::onLoad(ICore* c)
 {
-	core_ = c;
-	sampsharp::crash::install(c);
+    core_ = c;
+    sampsharp::crash::install(c);
 }
 
 void SampSharpComponent::provideConfiguration(ILogger& logger, IEarlyConfig& config, const bool defaults)
@@ -32,62 +32,62 @@ void SampSharpComponent::provideConfiguration(ILogger& logger, IEarlyConfig& con
         else if (config.getType(key) == ConfigOptionType_None) { \
             config.setString(key, value); \
         }
-	
-	initConfigString(CFG_DIRECTORY, "gamemode");
-	initConfigString(CFG_ASSEMBLY, "GameMode");
-	initConfigString(CFG_ENTRY_POINT_TYPE, "SampSharp.Entrypoint");
-	initConfigString(CFG_ENTRY_POINT_METHOD, "Initialize");
-	initConfigString(CFG_CLEANUP_METHOD, "Cleanup");
+    
+    initConfigString(CFG_DIRECTORY, "gamemode");
+    initConfigString(CFG_ASSEMBLY, "GameMode");
+    initConfigString(CFG_ENTRY_POINT_TYPE, "SampSharp.Entrypoint");
+    initConfigString(CFG_ENTRY_POINT_METHOD, "Initialize");
+    initConfigString(CFG_CLEANUP_METHOD, "Cleanup");
 }
 
 void SampSharpComponent::onInit(IComponentList* components)
 {
-	const IConfig& config = core_->getConfig();
+    const IConfig& config = core_->getConfig();
 
-	const auto directory = config.getString(CFG_DIRECTORY);
-	const auto assembly = config.getString(CFG_ASSEMBLY);
-	const auto entry_point_type = config.getString(CFG_ENTRY_POINT_TYPE);
-	const auto entry_point_method = config.getString(CFG_ENTRY_POINT_METHOD);
-	const auto cleanup_method = config.getString(CFG_CLEANUP_METHOD);
+    const auto directory = config.getString(CFG_DIRECTORY);
+    const auto assembly = config.getString(CFG_ASSEMBLY);
+    const auto entry_point_type = config.getString(CFG_ENTRY_POINT_TYPE);
+    const auto entry_point_method = config.getString(CFG_ENTRY_POINT_METHOD);
+    const auto cleanup_method = config.getString(CFG_CLEANUP_METHOD);
 
-	std::string entry_point = entry_point_type.to_string() + ", " + assembly.to_string();
-	const auto full_entry_point = StringView(entry_point);
+    std::string entry_point = entry_point_type.to_string() + ", " + assembly.to_string();
+    const auto full_entry_point = StringView(entry_point);
 
-	const char * error = nullptr;
-	
+    const char * error = nullptr;
+    
     if(!managed_host_.initialize(&error))
-	{
-		core_->logLn(Error, "Failed to initialize the .NET host framework resolver. Has the .NET runtime been installed?");
-		core_->logLn(Error, "Error message: %s", error);
-		return;
-	}
+    {
+        core_->logLn(Error, "Failed to initialize the .NET host framework resolver. Has the .NET runtime been installed?");
+        core_->logLn(Error, "Error message: %s", error);
+        return;
+    }
 
     if(!managed_host_.loadFor(directory, assembly, &error))
-	{
-		core_->logLn(Error, "Failed to initialize the .NET runtime for '%s/%s'. Is the '*.runtimeconfig.json' file available? Is the .NET runtime available?", directory.to_string().c_str(), assembly.to_string().c_str());
-		core_->logLn(Error, "Error message: %s", error);
-		return;
-	}
+    {
+        core_->logLn(Error, "Failed to initialize the .NET runtime for '%s/%s'. Is the '*.runtimeconfig.json' file available? Is the .NET runtime available?", directory.to_string().c_str(), assembly.to_string().c_str());
+        core_->logLn(Error, "Error message: %s", error);
+        return;
+    }
 
-	on_init_fn on_init;
-	if(!managed_host_.getEntryPoint(full_entry_point, entry_point_method, reinterpret_cast<void**>(&on_init), &error))
-	{
-		core_->logLn(Error, "The entrypoint '%s.%s, %s' could not be found.", entry_point_type.to_string().c_str(), entry_point_method.to_string().c_str(), assembly.to_string().c_str());
-		core_->logLn(Error, "Error message: %s", error);
-		return;
-	}
-	
-	if(!managed_host_.getEntryPoint(full_entry_point, cleanup_method, reinterpret_cast<void**>(&on_cleanup_), &error))
-	{
-		core_->logLn(Error, "The entrypoint '%s.%s, %s' could not be found.", entry_point_type.to_string().c_str(), cleanup_method.to_string().c_str(), assembly.to_string().c_str());
-		core_->logLn(Error, "Error message: %s", error);
-		return;
-	}
+    on_init_fn on_init;
+    if(!managed_host_.getEntryPoint(full_entry_point, entry_point_method, reinterpret_cast<void**>(&on_init), &error))
+    {
+        core_->logLn(Error, "The entrypoint '%s.%s, %s' could not be found.", entry_point_type.to_string().c_str(), entry_point_method.to_string().c_str(), assembly.to_string().c_str());
+        core_->logLn(Error, "Error message: %s", error);
+        return;
+    }
+    
+    if(!managed_host_.getEntryPoint(full_entry_point, cleanup_method, reinterpret_cast<void**>(&on_cleanup_), &error))
+    {
+        core_->logLn(Error, "The entrypoint '%s.%s, %s' could not be found.", entry_point_type.to_string().c_str(), cleanup_method.to_string().c_str(), assembly.to_string().c_str());
+        core_->logLn(Error, "Error message: %s", error);
+        return;
+    }
 
-	SampSharpInfo info { sizeof(SampSharpInfo), VERSION_API, componentVersion() };
-	SampSharpInitParams init { core_, components, &info };
-	
-	on_init(init);
+    SampSharpInfo info { VERSION_API, componentVersion() };
+    SampSharpInitParams init { core_, components, &info };
+    
+    on_init(init);
 }
 
 void SampSharpComponent::onReady()
@@ -96,12 +96,12 @@ void SampSharpComponent::onReady()
 
 void SampSharpComponent::free()
 {
-	if (on_cleanup_)
-	{
-		on_cleanup_();
-	}
-	
-	delete this;
+    if (on_cleanup_)
+    {
+        on_cleanup_();
+    }
+    
+    delete this;
 }
 
 void SampSharpComponent::reset()
@@ -110,9 +110,9 @@ void SampSharpComponent::reset()
 
 SampSharpComponent* SampSharpComponent::getInstance()
 {
-	if (instance_ == nullptr)
-	{
-		instance_ = new SampSharpComponent();
-	}
-	return instance_;
+    if (instance_ == nullptr)
+    {
+        instance_ = new SampSharpComponent();
+    }
+    return instance_;
 }

--- a/src/sampsharp-component/sampsharp-component.hpp
+++ b/src/sampsharp-component/sampsharp-component.hpp
@@ -6,30 +6,33 @@
 
 struct SampSharpInfo
 {
-	SampSharpInfo(size_t size, int api_version, SemanticVersion version) : 
-		size(size), 
-		api_version(api_version),
-		version(version) { }
+    SampSharpInfo(int api_version, SemanticVersion version) : 
+        size(sizeof(SampSharpInfo)), 
+        api_version(api_version),
+        version(version) { }
 
-	// sizeof(SampSharpInfo) for backwards compatibility
-	size_t size; 
-	// version of SampSharp component <> hosted API. Version mismatch will cause launch failure.
-	int api_version; 
-	// version of the SampSharp component
-	SemanticVersion version; 
+    // sizeof(SampSharpInfo) for backwards compatibility
+    size_t size; 
+    // version of SampSharp component <> hosted API. Version mismatch will cause launch failure.
+    int api_version; 
+    // version of the SampSharp component
+    SemanticVersion version; 
 };
 
 
 struct SampSharpInitParams
 {
-	SampSharpInitParams(ICore * core, IComponentList * componentList, SampSharpInfo * info) :
-		core(core),
-		componentList(componentList),
-		info(info) { }
+    SampSharpInitParams(ICore * core, IComponentList * componentList, SampSharpInfo * info) :
+        size(sizeof(SampSharpInitParams)),
+        info(info),
+        core(core),
+        componentList(componentList) { }
 
-	ICore * core;
-	IComponentList * componentList;
-	SampSharpInfo * info;
+    // sizeof(SampSharpInitParams) for backwards compatibility
+    size_t size; 
+    SampSharpInfo * info;
+    ICore * core;
+    IComponentList * componentList;
 };
 
 typedef void (CORECLR_DELEGATE_CALLTYPE *on_init_fn)(SampSharpInitParams);
@@ -37,34 +40,34 @@ typedef void (CORECLR_DELEGATE_CALLTYPE *on_cleanup_fn)();
 
 struct ISampSharpComponent : IComponent
 {
-	PROVIDE_UID(0x0B61929D1E94A319);
+    PROVIDE_UID(0x0B61929D1E94A319);
 };
 
 class SampSharpComponent final
-	: public ISampSharpComponent
+    : public ISampSharpComponent
 {
 private:
-	ICore * core_ = nullptr;
-	ManagedHost managed_host_ {};
-	inline static SampSharpComponent * instance_ = nullptr;
-	on_cleanup_fn on_cleanup_ = nullptr;
+    ICore * core_ = nullptr;
+    ManagedHost managed_host_ {};
+    inline static SampSharpComponent * instance_ = nullptr;
+    on_cleanup_fn on_cleanup_ = nullptr;
 
 public:
-	StringView componentName() const override;
+    StringView componentName() const override;
 
-	SemanticVersion componentVersion() const override;
+    SemanticVersion componentVersion() const override;
 
-	void onLoad(ICore * c) override;
+    void onLoad(ICore * c) override;
 
-	void provideConfiguration(ILogger & logger, IEarlyConfig & config, bool defaults) override;
-	
-	void onInit(IComponentList * components) override;
+    void provideConfiguration(ILogger & logger, IEarlyConfig & config, bool defaults) override;
+    
+    void onInit(IComponentList * components) override;
 
-	void onReady() override;
+    void onReady() override;
 
-	void free() override;
+    void free() override;
 
-	void reset() override;
-	
-	static SampSharpComponent * getInstance();
+    void reset() override;
+    
+    static SampSharpComponent * getInstance();
 };


### PR DESCRIPTION
Added version checker which validates the open.mp component supports the running managed library.

Version check runs as soon as possible : `EntryPoint.Initialize` -> `StartupContext.ctor` -> `StartupContext.VersionCheck`

Realigned `SampSharpInitParams` struct fields such that future updates won't break the version checker. If fields are now appended to `SampSharpInitParams`, it won't move the location of version indicators. The `SampSharpInfo` should be stable and never change, but for good measure, we keep a size check in the struct.


Also replaced tabs -> spaces